### PR TITLE
zenedge: claims rails 5 compat fix

### DIFF
--- a/lib/pg_sequencer/railtie.rb
+++ b/lib/pg_sequencer/railtie.rb
@@ -28,7 +28,7 @@ module PgSequencer
         end
 
         ActiveRecord::SchemaDumper.class_eval do
-          include PgSequencer::SchemaDumper
+          prepend PgSequencer::SchemaDumper
         end
 
       end

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -21,12 +21,8 @@ module PgSequencer
   module SchemaDumper
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :tables, :sequences
-    end
-
-    def tables_with_sequences(stream)
-      tables_without_sequences(stream)
+    def tables(stream)
+      super(stream)
       sequences(stream)
     end
 


### PR DESCRIPTION
"Fix deprecation warnings in Rails 5 by substituting alias_method_chain with Model.prepend"